### PR TITLE
sichert nun Directorys, logrotate rekursiv, diverse Systemzustände

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignoriere alle .txt Dateien im Verzeichnis backup/.config
+backup/.config/*.txt
+backup/.config/*.conf
+backup/.config/*.sh
+
+# Aber behalte .txt-muster Dateien
+!backup/.config/*.txt-muster
+!backup/.config/*.conf-muster
+!backup/.config/*.sh-muster

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Erlaube .config-Verzeichnis im 'backup'-Verzeichnis
+!backup/.config/
+
 # Ignoriere alle .txt Dateien im Verzeichnis backup/.config
 backup/.config/*.txt
 backup/.config/*.conf
@@ -7,3 +10,9 @@ backup/.config/*.sh
 !backup/.config/*.txt-muster
 !backup/.config/*.conf-muster
 !backup/.config/*.sh-muster
+
+# Ignoriere alles im 'backups'-Verzeichnis
+backup/backups/*
+
+# Erlaube 'README.md' im 'backups'-Verzeichnis
+!backup/backups/README.md

--- a/README.md
+++ b/README.md
@@ -6,19 +6,32 @@ Zum Sichern wird rclone verwendet, so dass die Daten in beliebigen Cloud-Speiche
 
 Die Sicherung wird nach einem konfigurierbaren Gerätenamen benannt. Die Anzahl der aufzubewahrenden täglichen Sicherungen ist ebenfalls konfigurierbar.
 
-Systemdateien, automatisch gesichert, müssen nicht in der config angegeben sein:
+## automatisch gesicherte Systemdateien
+Diese müssen nicht in der config angegeben sein:
+````
 /boot/config.txt
 /boot/cmdline.txt
 /proc/cpuinfo
 /etc/hostname
 /etc/logrotate.conf
-Crontabs von pi und root
 rclone config
-aktuelle Prozessliste (ps -ax)
+````
+
+## Systemzustände die gesichert werden
+Die Ausgabe nachfolgender Befehle werden ebenfalls gesichert
+````
+(sudo) crontab -l
+ps -ax
+systemctl list-units --type=service
+dpkg --get-selections
+lsblk
+df -h
+````
 
 # Versionen
 Dezember 2022   initiale Version
-Dezember 2023   Erweiterung um die Möglichkeit in der config auch Verzeichnisse anzugeben
+
+Dezember 2023   Erweiterung um die Möglichkeit in der config auch Verzeichnisse anzugeben und diverse Systembefahlausgaben
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # Raspberry-Pi-Backup-Cloud
-Raspberry Pi backup script to store parameterizable files in the cloud via rclone
+Backup Script zum sichern einer Raspberry Pi Installation. 
+Es werden zunächst eine Reihe von Systemdateien und Zuständen gesichert. Anschließend werden alle Dateien und Verzeichnisse gesichert, die in einer Konfigurationsdatei hinterlegt sind. Schließlich wird ein spezielles Backup Skript aufgerufen (falls vorhanden), in dem z.B. die Backup Anweisung zum Sichern einer Datenbank hinterlegt werden können.
+
+Zum Sichern wird rclone verwendet, so dass die Daten in beliebigen Cloud-Speichern oder auf Netz- oder auf lokalen Laufwerken gesichert werden können.
+
+Die Sicherung wird nach einem konfigurierbaren Gerätenamen benannt. Die Anzahl der aufzubewahrenden täglichen Sicherungen ist ebenfalls konfigurierbar.
+
+Systemdateien, automatisch gesichert, müssen nicht in der config angegeben sein:
+/boot/config.txt
+/boot/cmdline.txt
+/proc/cpuinfo
+/etc/hostname
+/etc/logrotate.conf
+Crontabs von pi und root
+rclone config
+aktuelle Prozessliste (ps -ax)
+
+# Versionen
+Dezember 2022   initiale Version
+Dezember 2023   Erweiterung um die Möglichkeit in der config auch Verzeichnisse anzugeben
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Raspberry-Pi-Backup-Cloud
-Backup Script zum sichern einer Raspberry Pi Installation. 
+Backup Script zum Sichern einer Raspberry Pi Installation. 
 Es werden zunächst eine Reihe von Systemdateien und Zuständen gesichert. Anschließend werden alle Dateien und Verzeichnisse gesichert, die in einer Konfigurationsdatei hinterlegt sind. Schließlich wird ein spezielles Backup Skript aufgerufen (falls vorhanden), in dem z.B. die Backup Anweisung zum Sichern einer Datenbank hinterlegt werden können.
 
 Zum Sichern wird rclone verwendet, so dass die Daten in beliebigen Cloud-Speichern oder auf Netz- oder auf lokalen Laufwerken gesichert werden können.
@@ -7,7 +7,7 @@ Zum Sichern wird rclone verwendet, so dass die Daten in beliebigen Cloud-Speiche
 Die Sicherung wird nach einem konfigurierbaren Gerätenamen benannt. Die Anzahl der aufzubewahrenden täglichen Sicherungen ist ebenfalls konfigurierbar.
 
 ## automatisch gesicherte Systemdateien
-Diese müssen nicht in der config angegeben sein:
+Diese müssen nicht in der config angegeben sein:  
 ````
 /boot/config.txt
 /boot/cmdline.txt
@@ -18,7 +18,7 @@ rclone config
 ````
 
 ## Systemzustände die gesichert werden
-Die Ausgabe nachfolgender Befehle werden ebenfalls gesichert
+Die Ausgabe nachfolgender Befehle werden ebenfalls gesichert  
 ````
 (sudo) crontab -l
 ps -ax
@@ -29,8 +29,7 @@ df -h
 ````
 
 # Versionen
-Dezember 2022   initiale Version
-
+Dezember 2022   initiale Version  
 Dezember 2023   Erweiterung um die Möglichkeit in der config auch Verzeichnisse anzugeben und diverse Systembefahlausgaben
 
 # Installation
@@ -78,7 +77,7 @@ Die Konfiguration für rclone befindet sich in ```.config/rclone.conf```
 
 
 ## ggf. hinzufügen eines Spezialskripts für weitere Sicherungen
-
+Ändern Sie dazu das Skript in
 ```.config/backup2ndScript.sh```
 
 
@@ -100,12 +99,15 @@ Folgende Zeilen sind in die crontab des Users root einzufügen
 
 # rclone installieren
 
-rclone bitte nach Anleitung unter https://rclone.org/install/ installieren
+rclone bitte nach Anleitung unter https://rclone.org/install/ installieren  
+(in der Regel ausführen des Kommandos ```sudo -v ; curl https://rclone.org/install.sh | sudo bash```)
 
+## neue Konfiguration erstellen
 Ein neuer Remote-Speicher kann über nachfolgendes Kommando eingerichtet werden
 ```
 rclone config
 ```
+Falls Sie bereits eine rclone.conf mit korrekten Angaben (aus einer anderen Installation) haben, lesen Sie bitte unten unter "vorhandene Konfiguration verwenden" weiter
 
 Für mein Google Drive mache ich nachfolgende Eingaben. Bitte beachten Sie, dass Sie vor diesem Schritt auf der Google Developer Console einen Account anlegen müssen und Ihre client_id und Ihren client_secret ermitteln müssen. Da Google die Verfahrensschritte hierzu immer wieder ändert, gebe ich hier keine Anleitung. Auf der [rclone Website](https://rclone.org/drive/#making-your-own-client-id) findet sich jedoch der Hinweis wie die Schritte aktuell sind.
 ```
@@ -131,4 +133,27 @@ Nach diesen Schritten haben Sie Zugriff auf Ihren Cloudspeicher. Dies können Si
 rclone -v lsf MeinGoogleDrive:
 ```
 Nun sollte Ihnen Ihr Google Drive aufgelistet werden.
+
+## vorhandene Konfiguration verwenden
+Falls Sie bereits eine funktionierende rclone.conf aus z. B. einer anderen Installation haben, können Sie das Einrichten vereinfachen. Nach der Installation von rclone kopieren Sie einfach die vorhandene Konfiguration an die entsprechenden Stellen und rclone ist damit vollständig konfiguriert.
+
+Kopieren Sie zunächst ihre vorhandene Konfiguration nach /home/pi/backup/.config/rclone.conf
+
+Dann führen Sie folgende Befehle aus  
+```
+cp /home/pi/backup/.config/rclone.conf /home/pi/.config/rclone/rclone.conf
+sudo cp /home/pi/backup/.config/rclone.conf /root/.config/rclone/rclone.conf
+```
+
+Falls Sie sichergehen wollen, dass die rclone.conf an die richtigen Stellen kopiert wird, überprüfen Sie die Defaultspeicherorte mit
+```
+rclone config
+```
+bzw.
+```
+sudo rclone config
+```
+beim erstmaligen Aufruf dieser Befehle ohne vorherige Konfiguration sollte folgende Meldungen erscheinen
+```NOTICE: Config file "/root/.config/rclone/rclone.conf" not found - using defaults```  
+Diese gibt den Standard-Speicherort an, den Sie oben für die Copy Befehle nutzen
 

--- a/backup/.config/backup_name.txt-muster
+++ b/backup/.config/backup_name.txt-muster
@@ -1,2 +1,4 @@
 RaspberryPiNameXyz
 15
+clouddrive
+backup/path

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -67,6 +67,7 @@ cp /boot/config.txt ${BACKUP_DIR}/boot
 cp /boot/cmdline.txt ${BACKUP_DIR}/boot
 cp /proc/cpuinfo ${BACKUP_DIR}/proc
 cp /etc/hostname ${BACKUP_DIR}/etc
+cp /etc/fstab ${BACKUP_DIR}/etc
 
 # logrotate
 cp /etc/logrotate.conf ${BACKUP_DIR}/etc
@@ -76,6 +77,14 @@ printf "\nCrontabs sichern ...\n"
 mkdir ${BACKUP_DIR}/crontab
 crontab -u pi -l > ${BACKUP_DIR}/crontab/crontab-pi.txt
 crontab -u root -l > ${BACKUP_DIR}/crontab/crontab-root.txt
+
+# Systemdienste, Software
+printf "\nSystemdienste sichern ...\n"
+mkdir ${BACKUP_DIR}/dienste_software
+systemctl list-units --type=service > ${BACKUP_DIR}/dienste_software/systemctl_list_units_service.txt
+dpkg --get-selections > ${BACKUP_DIR}/dienste_software/dpkg_installierte_packete.txt
+lsblk > ${BACKUP_DIR}/dienste_software/lsblk.txt
+df -h > ${BACKUP_DIR}/dienste_software/df_h.txt
 
 # rclone
 printf "\nrclone config sichern ...\n"

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -20,6 +20,8 @@ CONFIG_2ND_SCRIPT="${BACKUP_PFAD_LOKAL}/.config/backup2ndScript.sh"
 BACKUP_DIR_HEAD="default-geraet"
 BACKUP_DIR=${BACKUP_PFAD_LOKAL}/backups/${BACKUP_DIR_HEAD}-$(date +%Y%m%d-%H%M%S)
 BACKUP_ANZAHL="30"
+RCLONE_NAME="clouddrive"
+RCLONE_PATH="backup"
 
 # --------------------------------------------------
 # Konfiguration einlesen
@@ -33,14 +35,18 @@ echo "$(tr -d '\r' < ${CONFIG_DIRS})" > ${CONFIG_DIRS}
 # Geraetename und Anzahl aufzubewahrende Sicherungen lesen, setzen 
 # erste Zeile Geraetename, zweite Zeile Anzahl Tage
 # um sicherzugehen, wird Windows CRLF durch LF ersetzt
-echo "... Geraetename und Anzahl Sicherungen"
+echo "... Geraetename, Anzahl Sicherungen und rclone name einlesen"
 {
     read -r readline_name
     read -r readline_anzahl
+    read -r readline_rlonename
+    read -r readline_rlonepath
 } < ${CONFIG_NAME}
 BACKUP_DIR_HEAD=${readline_name}
 BACKUP_DIR=${BACKUP_PFAD_LOKAL}/backups/${BACKUP_DIR_HEAD}_$(date +%Y%m%d-%H%M%S)
 BACKUP_ANZAHL=$((${readline_anzahl}))
+RCLONE_NAME=$((${readline_rlonename}))
+RCLONE_PATH=$((${readline_rlonepath}))
 
 echo "... Backup Directory: $BACKUP_DIR"
 echo "... Backup Versionen: $BACKUP_ANZAHL"
@@ -141,6 +147,6 @@ pushd ${BACKUP_PFAD_LOKAL}/backups; ls -drt1 ${BACKUP_PFAD_LOKAL}/backups/${BACK
 
 # Synchronisieren in die Cloud
 echo "rclone sync starten ..." 
-rclone sync local:${BACKUP_PFAD_LOKAL}/backups LGBsharepoint:Backup/Geraete/Raspberry/${BACKUP_DIR_HEAD} --config ${CONFIG_RCLONE}
+rclone sync local:${BACKUP_PFAD_LOKAL}/backups ${RCLONE_NAME}:${RCLONE_PATH}/${BACKUP_DIR_HEAD} --config ${CONFIG_RCLONE}
 
 echo "Backup abgeschlossen!" 


### PR DESCRIPTION
Ein .gitignore wurde eingefügt
Das Skript wurde um folgende Funktionen ergänzt:
- Name des rclone Ziels kann in der Konfig Datei angegeben werden
- Cloud Pfad kann in der Konfig Datei angegeben werden
- logrotate Konfigurationen werden rekursiv gesichert
- Neben Dateien können in der Konfig nun auch Verzeichnisse angegeben werden
- /etc/fstab wird nun standardmäßig gesichert
- diverse Systemzustände werden automatisch gesichert
- rclone Konfiguration des Skriptes wird zusätzlich zu den Originären Configs von pi und root gesichert
